### PR TITLE
Fix undefined pronoun and ending label references

### DIFF
--- a/choicescript_game/scenes/familiar_selection.txt
+++ b/choicescript_game/scenes/familiar_selection.txt
@@ -176,7 +176,7 @@ What will you name your shadow-fox familiar?
 
 You approach the shadow-fox.
 
-${familiar_name} watches you with eyes that shimmer between colors—now silver, now gold, now deep violet. ${He_She} flickers in and out of visibility, never quite solid.
+${familiar_name} watches you with eyes that shimmer between colors—now silver, now gold, now deep violet. ${he_she} flickers in and out of visibility, never quite solid.
 
 *line_break
 
@@ -186,7 +186,7 @@ When you extend your hand, ${familiar_name} [i]melts[/i] into shadow and reforms
 
 The bond forms like a whisper in the dark.
 
-You feel ${familiar_name}'s consciousness—curious, secretive, loyal beyond measure. ${He_She} knows the spaces between spaces, the secrets hidden in shadows.
+You feel ${familiar_name}'s consciousness—curious, secretive, loyal beyond measure. ${he_she} knows the spaces between spaces, the secrets hidden in shadows.
 
 *line_break
 

--- a/choicescript_game/scenes/singing_dunes.txt
+++ b/choicescript_game/scenes/singing_dunes.txt
@@ -244,14 +244,14 @@ You step through the portal. Avalon's leyline energy washes over you, welcoming 
 *if desert_blessing
   But something has changed. You can feel truth and lies differently now—like a new sense awakened by the desert. Your truth-sworn sand pulses gently in your pocket, warm and reassuring.
 
-*goto_scene endings truthbound_ending
+*goto_scene endings truthbound_mage_ending
 
 *if (kael_approval = 1)
   You've grown, even if the desert didn't bless you. Sometimes wisdom comes from walking carefully rather than boldly.
 
-*goto_scene endings balanced_ending
+*goto_scene endings balanced_mage_ending
 
 *if kael_approval <= 0
   You return to Avalon humbled, carrying lessons learned the hard way.
 
-*goto_scene endings humbled_ending
+*goto_scene endings humbled_student_ending

--- a/choicescript_game/scenes/verdant_tithe.txt
+++ b/choicescript_game/scenes/verdant_tithe.txt
@@ -373,9 +373,9 @@ Izack addresses the group one final time. "You've learned that consciousness its
   *goto_scene endings heartwood_guardian_ending
 
 *if forest_bond >= 3
-  *goto_scene endings forestbound_ending
+  *goto_scene endings forestbound_guardian_ending
 
 *if forest_blessing
-  *goto_scene endings balanced_ending
+  *goto_scene endings balanced_mage_ending
 
-*goto_scene endings standard_ending
+*goto_scene endings standard_path_ending


### PR DESCRIPTION
## Summary
- correct shadow-fox familiar text to use existing lowercase pronoun variable
- update Singing Dunes endings to jump to labels that exist in endings.txt
- align Verdant Tithe wrap-up with the available ending labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fdc93ba3483229d3dfc2eee3556a0)