### PR TITLE
Extend Avalon ChoiceScript demo with convergence chapter

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -14,7 +14,7 @@ This repository now includes a small ChoiceScript-friendly scaffolding to help y
 
 ## Load the sample Avalon demo scenes
 1. Ensure `game/choicescript/` exists (see bootstrap step above).
-2. Run `./game/sync_scenes.sh` to copy the sample scenes from `game/scenes/` into `game/choicescript/web/mygame/`.
+2. Run `./game/sync_scenes.sh` to copy the sample scenes from `game/scenes/` into `game/choicescript/web/mygame/scenes/` (the script creates the folder if needed).
 3. Launch the ChoiceScript local server from inside `game/choicescript/`:
    - Windows: double-click `run-server.bat` (may show as `run-server`).
    - macOS: double-click `serve.command` (you may need to allow it under System Settings > Gatekeeper the first time).
@@ -24,12 +24,13 @@ This repository now includes a small ChoiceScript-friendly scaffolding to help y
 ### Included demo content
 - `startup`, `prologue`, and `crossroads` introduce stat creation and *goto_scene branching.
 - `archives`, `wardens`, and `council` showcase stat checks, gated options, and different narrative tones.
+- `convergence` reacts to accumulated flags and stats before handing off to the wrap-up.
 - `epilogue` wraps up the path with a replay hook.
 - `choicescript_stats.txt` enables the “Show Stats” button with meters for Honor, Attunement, mentor name, and council trust, plus a blurb that reacts to your flags.
 
 ## Editing and extending scenes
 - The sample scenes live in `game/scenes/`. Edit them directly there.
-- Run `./game/sync_scenes.sh` after changes to push updates into the engine’s `web/mygame/` folder.
+- Run `./game/sync_scenes.sh` after changes to push updates into the engine’s `web/mygame/scenes/` folder.
 - Scene order and available files are controlled by `*scene_list` at the top of `startup.txt`.
 - To add stats, edit `choicescript_stats.txt`; you can use `*stat_chart` to display new variables.
 

--- a/game/scenes/archives.txt
+++ b/game/scenes/archives.txt
@@ -18,4 +18,4 @@ You step into a crystalline hall where voices whisper in harmonics. Tomes float 
 
 *label after_archives
 An attendant smiles. "The council likes when scholars bring back clarity."
-*goto_scene epilogue
+*goto_scene convergence

--- a/game/scenes/convergence.txt
+++ b/game/scenes/convergence.txt
@@ -1,0 +1,51 @@
+You emerge onto a circular landing where the three portals meet. A lattice of light hums beneath your feet, recording traces of what you've done.
+
+*comment Offer bespoke acknowledgments based on prior flags and stats.
+*if (oathbound and resonance_mark)
+  The Spiral recognizes both your oath and your resonance. Elders and wardens glance your way, curious which you will lean on.
+*elseif oathbound
+  Your oath to the wardens anchors the lattice, bright as a drawn blade.
+*elseif resonance_mark
+  The Spiral's song follows you, weaving a counter-melody through the hall.
+*else
+  For now, your choices leave only faint trails. Avalon waits to see how you'll impress it.
+
+A courier approaches with three sealed missives, each bearing a different crest.
+
+*choice
+  #Answer the research call from the Aerie Conservatory.
+    The missive requests someone attuned to the Spiral to help tune a wavering beacon.
+    *if attunement >= 65
+      Your earlier harmonics steady the beacon immediately. Archivists scribble notes as the signal clarifies.
+      *set attunement +5
+      *set council_trust +5
+      *goto after_convergence
+    *else
+      The beacon sputters before stabilizing. You promise to return with sharper focus.
+      *set attunement +5
+      *goto after_convergence
+  #Join the wardens escorting dignitaries across the skybridge.
+    The missive warns of turbulence and rogue drones.
+    *if honor >= 65
+      You anticipate each crosswind and shield the dignitaries flawlessly. The captain nods: "Reliable as ever."
+      *set honor +5
+      *set council_trust +5
+      *goto after_convergence
+    *else
+      The escort completes with a few scrapes, but your vigilance earns respect.
+      *set honor +5
+      *goto after_convergence
+  #Seek ${mentor}'s counsel on weaving both paths.
+    ${mentor} greets you with tea and charts showing overlaps between wardens and archivists.
+    *if (honor >= 60) and (attunement >= 60)
+      Together you draft a joint initiative, convincing the council to fund it.
+      *set council_trust +10
+      *goto after_convergence
+    *else
+      ${mentor} challenges you to refine your goals before the council convenes again.
+      *set council_trust +5
+      *goto after_convergence
+
+*label after_convergence
+The lattice quiets, storing your response. A lift descends toward an open balcony.
+*goto_scene epilogue

--- a/game/scenes/council.txt
+++ b/game/scenes/council.txt
@@ -26,4 +26,4 @@ The council chamber is a ring of suspended platforms. Holographic maps of the Sp
 
 *label after_council
 A bell tolls from deeper within the chamber, signaling a new phase of your time in Avalon.
-*goto_scene epilogue
+*goto_scene convergence

--- a/game/scenes/crossroads.txt
+++ b/game/scenes/crossroads.txt
@@ -1,4 +1,4 @@
-Beyond the council doors, a triad of portals rotates in perfect alignment. Each promises a different future.
+Beyond the council doors, a triad of portals rotates in perfect alignment. Each promises a different future. Threads of light braid between them, knitting the fates of Avalon together.
 
 *comment Branch into dedicated scenes to show *goto_scene usage and stat checks.
 *choice
@@ -6,8 +6,9 @@ Beyond the council doors, a triad of portals rotates in perfect alignment. Each 
     *if attunement >= 60
       The portal sings in harmony with you. Knowledge floods your mind, and the Spiral welcomes you as a student.
       *goto_scene archives
-    Your attunement falters, and the portal resists. You retreat to study more.
-    *finish
+    Your attunement falters, and the portal resists. You gather stray harmonics to study later.
+    *set attunement +5
+    *goto_scene council
   #Enter the martial hall marked by silver spears.
     The wardens salute as you pass. Honor carries you forward into service.
     *goto_scene wardens

--- a/game/scenes/epilogue.txt
+++ b/game/scenes/epilogue.txt
@@ -1,4 +1,4 @@
-You pause at the threshold of a balcony overlooking the Spiral. Choices made today ripple outward.
+You pause at the threshold of a balcony overlooking the Spiral. Choices made today ripple outward. Couriers and wardens move below, carrying the effects of your decisions into the wider city.
 
 *if resonance_mark
   The Spiral thrums in time with your pulse, marking you as one who listens.
@@ -6,6 +6,13 @@ You pause at the threshold of a balcony overlooking the Spiral. Choices made tod
   The badge of the wardens gleams. Duty anchors your steps.
 *else
   The council watches, curious which oath you will claim.
+
+*if council_trust >= 70
+  An elder leans close. "You've earned the room to propose something bold."
+*elseif council_trust >= 55
+  The council's sigils shimmer with measured confidence in you.
+*else
+  Whispers ripple along the balcony. Trust is budding but not yet firm.
 
 *comment Offer a small wrap-up and replay hook.
 *choice
@@ -15,5 +22,5 @@ You pause at the threshold of a balcony overlooking the Spiral. Choices made tod
     Council trust: ${council_trust}
     *finish
   #Step forward into the Spiral once more.
-    The path shifts with every decision.
+    The path shifts with every decision. New branches spiral outward from here.
     *ending

--- a/game/scenes/startup.txt
+++ b/game/scenes/startup.txt
@@ -7,6 +7,7 @@
   council
   archives
   wardens
+  convergence
   epilogue
 
 *create honor 50
@@ -16,7 +17,7 @@
 *create oathbound false
 *create resonance_mark false
 
-You stand before the gates of Avalon, the Spiral of Eternity humming under your feet. Today you choose how you will meet the city's secrets.
+You stand before the gates of Avalon, the Spiral of Eternity humming under your feet. Today you choose how you will meet the city's secrets. Airships arc between spires overhead, their contrails forming luminous sigils that fade as quickly as they appear.
 
 *choice
   #Study the ley lines that weave through the plaza.

--- a/game/scenes/wardens.txt
+++ b/game/scenes/wardens.txt
@@ -24,4 +24,4 @@ The martial hall thrums with sparring and shouted cadence. Racks of spears line 
 
 *label after_wardens
 The captain clasps your forearm. "When the council calls, remember this hall."
-*goto_scene epilogue
+*goto_scene convergence

--- a/game/sync_scenes.sh
+++ b/game/sync_scenes.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_DIR="$SCRIPT_DIR/scenes"
-TARGET_DIR="$SCRIPT_DIR/choicescript/web/mygame"
+TARGET_DIR="$SCRIPT_DIR/choicescript/web/mygame/scenes"
 
 if [ ! -d "$SCRIPT_DIR/choicescript" ]; then
   echo "ChoiceScript not found in $SCRIPT_DIR/choicescript. Run ./game/bootstrap_choicescript.sh first." >&2
@@ -11,8 +11,8 @@ if [ ! -d "$SCRIPT_DIR/choicescript" ]; then
 fi
 
 if [ ! -d "$TARGET_DIR" ]; then
-  echo "Target directory $TARGET_DIR does not exist. Ensure the ChoiceScript clone has the expected layout." >&2
-  exit 1
+  echo "Target directory $TARGET_DIR does not exist. Creating it to hold synced scenes..." >&2
+  mkdir -p "$TARGET_DIR"
 fi
 
 echo "Copying scenes from $SOURCE_DIR to $TARGET_DIR..."


### PR DESCRIPTION
## Summary
- add a new convergence scene that reacts to player flags and offers stat-aware missives
- route archives, wardens, and council branches through the new convergence step and polish earlier portal text
- expand the epilogue's reactive wrap-up and note the new flow in the README

## Testing
- not run (narrative content and documentation updates only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920262cceb08322b354952834ab0f91)