### PR TITLE
Something i Guess

### DIFF
--- a/docs/avalon_materials/antropic for ai stuff.txt
+++ b/docs/avalon_materials/antropic for ai stuff.txt
@@ -1,4 +1,3 @@
-antropic for ai stuff 
+antropic for ai stuff
 https://console.anthropic.com/dashboard
-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
-
+Anthropic API key removed. Set ANTHROPIC_API_KEY in your environment instead of committing secrets to the repo.


### PR DESCRIPTION
## Summary
- delete the plaintext Anthropic API key from `docs/avalon_materials/antropic for ai stuff.txt`
- add guidance to use the ANTHROPIC_API_KEY environment variable instead of committing secrets

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921154a229c832296be23802d92bf55)