### PR TITLE
Add four new campaign arcs with unique finales

### DIFF
--- a/choicescript_game/scenes/avalon_crisis.txt
+++ b/choicescript_game/scenes/avalon_crisis.txt
@@ -39,6 +39,112 @@ But even they're struggling.
 
 *page_break
 
+*comment Alternate campaign climaxes
+*if campaign_route = "cooperative_arc"
+  *goto cooperative_crisis
+*if campaign_route = "rivalry_arc"
+  *goto rivalry_crisis
+*if campaign_route = "redemption_arc"
+  *goto redemption_crisis
+*if campaign_route = "political_arc"
+  *goto political_crisis
+
+*label cooperative_crisis
+
+[b]== THE ACCORD HOLDS THE LINE ==[/b]
+
+*line_break
+
+You deploy the shared thesis weave from the Dimensional Loom, linking every volunteer into one stabilizing net around the Spiral Spire.
+
+*page_break
+
+The hostile entities slam against it, but your Accord adapts—rotating mana flow, swapping casters, keeping the lattice intact.
+
+*line_break
+
+*set collaboration +10
+*set cooperative_accord +5
+*set campaign_finale "cooperative_mastery"
+
+*page_break
+
+When the final tear seals, cheers ripple through the network. Avalon stands because you proved collaboration could be infrastructure.
+
+*goto_scene endings
+
+*label rivalry_crisis
+
+[b]== THE FINAL DUEL ==[/b]
+
+*line_break
+
+One entity steps forward, mirroring your own aura. The academy watches as you accept its challenge, rivalry distilled into a single duel for Avalon's fate.
+
+*page_break
+
+You outmaneuver it with every trick learned from years of competition. Grey and the others watch silently, grudging respect shining when your final strike shatters the invader.
+
+*line_break
+
+*set rivalry_heat +10
+*set power +10
+*set campaign_finale "rivalry_champion"
+
+*page_break
+
+Avalon survives because you were willing to stake everything on your own edge—and win.
+
+*goto_scene endings
+
+*label redemption_crisis
+
+[b]== MAKING IT RIGHT ==[/b]
+
+*line_break
+
+You anchor the damaged sections of Avalon with your guilt-ward, absorbing the backlash yourself. Each pulse hurts, but the cracks knit closed.
+
+*page_break
+
+Aria channels extra power into you; Izack steadies the flow. Together, you convert every ounce of remorse into protection for the academy.
+
+*line_break
+
+*set redemption_oath true
+*set empathy +5
+*set campaign_finale "redemption_guardian"
+
+*page_break
+
+Avalon endures. The ledger in your mind finally feels lighter.
+
+*goto_scene endings
+
+*label political_crisis
+
+[b]== THE PACT ACTIVATES ==[/b]
+
+*line_break
+
+You unleash the emergency mutual-aid pact. Portals bloom as allied envoys arrive, adding their magic to Avalon's defense while you negotiate a cease-fire with the leading entity.
+
+*page_break
+
+Your careful leverage pays off: the attackers stand down, unwilling to face a united multiverse and impressed by your honor-bound diplomacy.
+
+*line_break
+
+*set manipulation_network +10
+*set collaboration +5
+*set campaign_finale "political_weaver"
+
+*page_break
+
+Avalon is saved not by force, but by the alliances you wove in secret.
+
+*goto_scene endings
+
 *choice
   #Lead the collaborative defense - unite everyone's magic
     *if collaborative_magic >= 70

--- a/choicescript_game/scenes/collaborative_mastery.txt
+++ b/choicescript_game/scenes/collaborative_mastery.txt
@@ -1,0 +1,61 @@
+*comment Cooperative Scholar Campaign arc
+
+*label start
+
+[b]== THE COOPERATIVE SCHOLAR CAMPAIGN ==[/b]
+
+*line_break
+
+You claim an abandoned tower suite and turn it into a shared laboratory—whiteboards, glowing sigils, and hammocks for all-nighters. Six classmates sign on immediately.
+
+*page_break
+
+Every week in Year Two becomes a symposium. You facilitate rituals that blend half a dozen magical philosophies, publishing under the banner [i]The Accord[/i].
+
+*line_break
+
+*set collaborative_magic +10
+*set cooperative_accord +10
+*set collaboration +5
+
+*page_break
+
+[b]== YEAR THREE: COLLECTIVE MASTERY ==[/b]
+
+*line_break
+
+By now, the Accord has its own crest. You rotate leadership, teach democratic spell design, and invite even rival cohorts to contribute. Aria grudgingly admits your experiments are accelerating research without sacrificing safety.
+
+*line_break
+
+*set knowledge +10
+*set empathy +5
+*set fame +5
+
+*page_break
+
+[b]== YEAR FOUR: THE SHARED THESIS ==[/b]
+
+*line_break
+
+Instead of a solo thesis, you propose a [i]joint[/i] dimensional weave that lets multiple mages anchor a spell simultaneously. Faculty resist—until Izack sees the stability metrics.
+
+*line_break
+
+*set cooperative_accord +10
+*set dimensional_magic +5
+*set campaign_route "cooperative_arc"
+
+*page_break
+
+[i]"You've turned collaboration into infrastructure,"[/i] Polly whispers. [i]"If anyone can save Avalon together, it's you."[/i]
+
+*line_break
+
+[b]A crisis alarm ripples across the campus.[/b]
+
+*page_break
+
+*finish The Cooperative Accord answers the call
+
+*goto_scene year_two_crisis

--- a/choicescript_game/scenes/endings.txt
+++ b/choicescript_game/scenes/endings.txt
@@ -15,6 +15,86 @@ The Spiral Spire gleams above you, its impossible geometry catching the afternoo
 *comment DETERMINE ENDING BASED ON STATS AND CHOICES
 *comment ================================================
 
+*if campaign_finale = "cooperative_mastery"
+  *goto cooperative_arc_finale
+
+*if campaign_finale = "rivalry_champion"
+  *goto rivalry_arc_finale
+
+*if campaign_finale = "redemption_guardian"
+  *goto redemption_arc_finale
+
+*if campaign_finale = "political_weaver"
+  *goto political_arc_finale
+
+*comment ================================================
+*comment CAMPAIGN ARC ENDINGS
+*comment ================================================
+
+*label cooperative_arc_finale
+
+[b]== LEGACY OF THE ACCORD ==[/b]
+
+*line_break
+
+The Hall of Threads hums with shared magic. Your lattice from the Loom now reinforces Avalon's anchor permanently, credits etched with every Accord member's name beside yours.
+
+*line_break
+
+Izack announces a new department dedicated to collective casting. [i]"${name} proved collaboration isn't a tactic—it's infrastructure."[/i]
+
+*line_break
+
+*finish
+
+*label rivalry_arc_finale
+
+[b]== THE UNDISPUTED CHAMPION ==[/b]
+
+*line_break
+
+The gauntlet trophy rests in the Spiral Spire, its plaque reading: [i]"Victory keeps Avalon alive."[/i] Rivals nod respectfully as you pass; competition became protection under your lead.
+
+*line_break
+
+Zara offers you a post as strategic duelist-in-residence. You accept—with conditions that future ladders serve Avalon's safety, not ego.
+
+*line_break
+
+*finish
+
+*label redemption_arc_finale
+
+[b]== GUARDIAN OF SECOND CHANCES ==[/b]
+
+*line_break
+
+The ledger of debts is sealed with a final rune. Students whisper about the mage who turned remorse into power and rebuilt what others broke.
+
+*line_break
+
+Aria hands you the key to the new Restoration Annex. [i]"Lead them,"[/i] she says. [i]"Teach them that repair is as heroic as discovery."[/i]
+
+*line_break
+
+*finish
+
+*label political_arc_finale
+
+[b]== WEAVER OF COUNCILS ==[/b]
+
+*line_break
+
+Ambassadors crowd the courtyard, each bound by the pact you brokered. Avalon's first standing council of realms convenes with you at its head, a silver signet glinting on your finger.
+
+*line_break
+
+Izack smiles quietly. [i]"You made Avalon not just a school, but a promised ally."[/i]
+
+*line_break
+
+*finish
+
 *comment Highest tier endings - Partnership and Mastery
 *if (artifact_earned = "Glacier Partnership") and (collaboration > 80)
   *goto collaborative_master

--- a/choicescript_game/scenes/final_expedition.txt
+++ b/choicescript_game/scenes/final_expedition.txt
@@ -11,6 +11,16 @@
 
 All senior students must complete one final expedition before graduation.
 
+*comment Alternate campaign finales
+*if campaign_route = "cooperative_arc"
+  *goto cooperative_final_expedition
+*if campaign_route = "rivalry_arc"
+  *goto rivalry_final_expedition
+*if campaign_route = "redemption_arc"
+  *goto redemption_final_expedition
+*if campaign_route = "political_arc"
+  *goto political_final_expedition
+
 *page_break
 
 [i]"This isn't like your first-year field trips. This is master-level. The danger is real."[/i]
@@ -20,6 +30,106 @@ All senior students must complete one final expedition before graduation.
 You have a choice of destinations:
 
 *page_break
+
+*label cooperative_final_expedition
+
+[b]== THE ACCORD'S FINAL FIELD TEST ==[/b]
+
+*line_break
+
+You petition Izack for permission to take your entire Accord into the Dimensional Loom—a realm that mirrors the caster's teamwork. The Loom accepts only linked groups.
+
+*page_break
+
+Inside, spells only function when woven together. You coordinate triads, rotating leaders every minute. When the Loom throws paradox storms, your shared thesis weave holds.
+
+*line_break
+
+*set collaboration +10
+*set cooperative_accord +10
+*set fame +10
+*set campaign_finale "cooperative_mastery"
+
+*page_break
+
+You emerge with a lattice of shimmering thread—a physical proof that collective casting can stabilize any anchor. The council cannot ignore it.
+
+*goto_scene avalon_crisis
+
+*label rivalry_final_expedition
+
+[b]== THE CHAMPION'S GAUNTLET ==[/b]
+
+*line_break
+
+Zara arranges a sanctioned gauntlet in the Dimensional Fringe: mirrored constructs built from every rival's best spell. Beat them all, and you become Avalon's strategic champion.
+
+*page_break
+
+You duel reflections of Grey's subtle wards, Aria's razor equations, and your own ambition made manifest. Each victory sharpens your focus and your fame.
+
+*line_break
+
+*set rivalry_heat +10
+*set power +10
+*set fame +10
+*set campaign_finale "rivalry_champion"
+
+*page_break
+
+When the final mirror bows, the title is yours—and with it, responsibility for Avalon's front line.
+
+*goto_scene avalon_crisis
+
+*label redemption_final_expedition
+
+[b]== THE DEBT RECKONING ==[/b]
+
+*line_break
+
+You return to the scarred pocket realm you once destabilized. This time, you bring the guilt-ward, allies, and a resolve forged by years of atonement.
+
+*page_break
+
+You anchor the realm's heart, absorbing backlash that would have shattered the team. The land steadies; grateful spirits whisper forgiveness.
+
+*line_break
+
+*set redemption_oath true
+*set empathy +5
+*set living_magic +5
+*set campaign_finale "redemption_guardian"
+
+*page_break
+
+You leave the realm whole, carrying a promise: Avalon will not repeat its mistakes.
+
+*goto_scene avalon_crisis
+
+*label political_final_expedition
+
+[b]== THE QUIET SUMMIT ==[/b]
+
+*line_break
+
+You organize a clandestine summit in a neutral pocket dimension, inviting rival ambassadors to sign an emergency mutual-aid pact for Avalon.
+
+*page_break
+
+Negotiations are tense. You deploy secrets, favors, and carefully timed gestures until signatures flow.
+
+*line_break
+
+*set manipulation_network +10
+*set collaboration +5
+*set fame +10
+*set campaign_finale "political_weaver"
+
+*page_break
+
+The pact grants Avalon reinforcements the moment the crisis hits.
+
+*goto_scene avalon_crisis
 
 *choice
   #Return to the location you visited in Year 1 (advanced challenges)

--- a/choicescript_game/scenes/path_selection.txt
+++ b/choicescript_game/scenes/path_selection.txt
@@ -235,8 +235,201 @@ Which door do you approach?
   #The Diplomatic Path—I want to bridge worlds and prevent conflicts through understanding.
     *goto confirm_diplomatic
 
+  #The Cooperative Scholar Campaign—lead a coalition of peers to reinvent collaborative magic.
+    *goto cooperative_pitch
+
+  #The Rivalry Ascent—pit yourself against Avalon's best and let competition forge your legend.
+    *goto rivalry_pitch
+
+  #The Redemption Arc—prove that mistakes can become miracles by taking on Avalon's most dangerous debts.
+    *goto redemption_pitch
+
+  #The Political Web—quietly shape councils and treaties to secure power through influence.
+    *goto manipulator_pitch
+
   #I need more information before deciding.
     *goto more_information
+
+*comment ================================================
+*comment ALTERNATE CAMPAIGN ROUTES
+*comment ================================================
+
+*label cooperative_pitch
+
+Aria raises an eyebrow as you study the three doors, then look past them at the faculty table itself. "You want something beyond the usual?"
+
+*page_break
+
+"I want to build a [i]team[/i]," you say. "A cohort that lives in the labs, shares theories, and treats collaboration as the entire curriculum." Izack's eyes brighten.
+
+*line_break
+
+This campaign would mean convening monthly symposiums, designing shared rituals, and publishing as a collective. It would also mean owning the consequences together.
+
+*page_break
+
+*choice
+  #Yes. I want to lead the Cooperative Scholar Campaign.
+    *set chosen_path "Cooperative Scholar"
+    *set campaign_route "cooperative_arc"
+    *set cooperative_accord +15
+    *set collaboration +10
+    *set knowledge +5
+    *goto cooperative_commitment
+
+  #Actually, I need to reconsider.
+    *goto reflection_moment
+
+*label cooperative_commitment
+
+Izack presses a shimmering sigil into your palm. [b]"Then convene the Accord,"[/b] he says. [b]"You'll have access to unused tower space and peer stipends. Make something new."[/b]
+
+*line_break
+
+*set aria_relationship +5
+*set izack_relationship +5
+
+*page_break
+
+[i]"A study group on steroids,"[/i] Polly muses. [i]"Or the birth of a scholarly faction. Either way, you're about to live in the Archives."[/i]
+
+*page_break
+
+*finish To be continued in: Cooperative Scholar Campaign
+
+*goto_scene collaborative_mastery
+
+*label rivalry_pitch
+
+Zara notices the way you size up the other students—Grey, Alaric, the prodigies who think they own the place.
+
+*page_break
+
+"Competition motivates you," she says. "You want to prove you're the strongest student Avalon has seen in generations."
+
+*line_break
+
+Choosing this means formal duels, public research challenges, and a scoreboard in the common hall. Someone will always be hunting your flaws.
+
+*page_break
+
+*choice
+  #Yes. Rivalry will forge me into something sharper.
+    *set chosen_path "Rivalry Ascent"
+    *set campaign_route "rivalry_arc"
+    *set rivalry_heat +20
+    *set power +10
+    *set confidence +5
+    *goto rivalry_commitment
+
+  #Actually, I need to reconsider.
+    *goto reflection_moment
+
+*label rivalry_commitment
+
+Zara clasps your forearm, grin fierce. [b]"I'll sanction the dueling ladder. But understand: no one bows out. Every victory paints a target on you."[/b]
+
+*line_break
+
+*set zara_relationship +10
+
+*page_break
+
+Polly lands on your shoulder. [i]"Bold. Dangerous. Dramatic. I approve."[/i]
+
+*page_break
+
+*finish To be continued in: Rivalry Ascent
+
+*goto_scene rivalry_path
+
+*label redemption_pitch
+
+You glance at the World Tree's scar from last year, remembering the close call you caused—or failed to prevent.
+
+*page_break
+
+"I don't want prestige," you admit. "I want to fix things I've broken. To take the dangerous assignments no one else will touch."
+
+*line_break
+
+Izack's expression softens. "A redemption campaign," he murmurs. "Difficult. Unforgiving. But meaningful."
+
+*page_break
+
+*choice
+  #Yes. Give me the risky debts to repay.
+    *set chosen_path "Redemption Arc"
+    *set campaign_route "redemption_arc"
+    *set redemption_oath true
+    *set empathy +10
+    *set stress +5
+    *goto redemption_commitment
+
+  #Actually, I need to reconsider.
+    *goto reflection_moment
+
+*label redemption_commitment
+
+Aria places a rune-sealed ledger in your hands. [b]"These are Avalon's unresolved harms. You'll take responsibility for them. No glory. Only repair."[/b]
+
+*line_break
+
+*set aria_relationship +8
+
+*page_break
+
+Polly whistles softly. [i]"That's heavy, ${name}. But if anyone can turn guilt into greatness, it's you."[/i]
+
+*page_break
+
+*finish To be continued in: Redemption Arc
+
+*goto_scene redemption_path
+
+*label manipulator_pitch
+
+Near the golden diplomatic door, you notice the council balcony overhead. It's half-empty. Power sits there quietly, waiting.
+
+*page_break
+
+"Someone has to shape who enters those rooms," you say. "Not by speeches. By alliances, secrets, and favors."
+
+*line_break
+
+Izack gives you a long, assessing look. "A political web. Subtle. Dangerous. Effective—if you stay ethical." Zara just smirks.
+
+*page_break
+
+*choice
+  #Yes. I'll weave influence until Avalon listens when I whisper.
+    *set chosen_path "Political Web"
+    *set campaign_route "political_arc"
+    *set manipulation_network +15
+    *set empathy +5
+    *set fame +5
+    *goto manipulator_commitment
+
+  #Actually, I need to reconsider.
+    *goto reflection_moment
+
+*label manipulator_commitment
+
+Izack hands you a silver signet. [b]"Council access. Quietly. Use it to prevent crises before they reach the field."[/b]
+
+*line_break
+
+*set izack_relationship +8
+
+*page_break
+
+[i]"Congratulations,"[/i] Polly says dryly. [i]"You're about to learn how much gossip can save—or doom—a realm."[/i]
+
+*page_break
+
+*finish To be continued in: Political Web
+
+*goto_scene political_web
 
 *comment ================================================
 
@@ -413,6 +606,7 @@ Aria's expression brightens—subtle, but genuine. "You're choosing the Research
 *choice
   #Yes. I want to understand the deepest truths of magic.
     *set chosen_path "research"
+    *set campaign_route "core_research"
     *goto research_commitment
 
   #Actually, let me reconsider.
@@ -433,6 +627,7 @@ Zara nods with approval. "You're choosing the Combat Path?"
 *choice
   #Yes. I want to defend the realms and become a battle mage.
     *set chosen_path "combat"
+    *set campaign_route "core_combat"
     *goto combat_commitment
 
   #Actually, let me reconsider.
@@ -453,6 +648,7 @@ Izack's smile is warm and welcoming. "You're choosing the Diplomatic Path?"
 *choice
   #Yes. I want to build bridges between worlds.
     *set chosen_path "diplomatic"
+    *set campaign_route "core_diplomatic"
     *goto diplomatic_commitment
 
   #Actually, let me reconsider.

--- a/choicescript_game/scenes/political_web.txt
+++ b/choicescript_game/scenes/political_web.txt
@@ -1,0 +1,62 @@
+*comment Political manipulator arc
+
+*label start
+
+[b]== THE POLITICAL WEB ==[/b]
+
+*line_break
+
+You begin Year Two in council galleries instead of classrooms. You learn who controls scholarship budgets, which ambassadors feud in private, and how to trade favors without leaving fingerprints.
+
+*page_break
+
+Quiet meetings replace sparring matches. You orchestrate seating charts that keep rivals apart and allies aligned, all while drafting memos that steer policy toward stability.
+
+*line_break
+
+*set manipulation_network +10
+*set empathy +5
+*set communication_vs_domination -5
+*set fame +5
+
+*page_break
+
+[b]== YEAR THREE: THREADS AND LEVERS ==[/b]
+
+*line_break
+
+You broker clandestine pacts between student factions, slipping protection clauses into inter-realm treaties. Izack starts asking for your read before major votes.
+
+*line_break
+
+*set manipulation_network +10
+*set knowledge +5
+*set collaboration +5
+
+*page_break
+
+[b]== YEAR FOUR: SHADOW COUNCIL ==[/b]
+
+*line_break
+
+By fourth year, you're effectively running Avalon's unofficial agenda—balancing ethical compromises with necessary manipulations. One wrong whisper could topple the whole design.
+
+*line_break
+
+*set campaign_route "political_arc"
+*set stress +5
+*set fame +10
+
+*page_break
+
+[i]"Power doesn't have to shout,"[/i] Polly notes. [i]"But it does have to choose when to speak."[/i]
+
+*line_break
+
+An alarm shreds the quiet council chamber. The crisis will test whether your web can hold.
+
+*page_break
+
+*finish The political web is summoned to act
+
+*goto_scene year_two_crisis

--- a/choicescript_game/scenes/redemption_path.txt
+++ b/choicescript_game/scenes/redemption_path.txt
@@ -1,0 +1,62 @@
+*comment Redemption arc
+
+*label start
+
+[b]== THE REDEMPTION ARC ==[/b]
+
+*line_break
+
+Aria's ledger lists forgotten promises: a library wing needing restoration, a small realm still scarred from a failed experiment, a student you once slighted. You sign your name beside each debt.
+
+*page_break
+
+Year Two becomes repair work. You mend rifts, apologize publicly, and study healing magic until your hands tremble from exertion.
+
+*line_break
+
+*set redemption_oath true
+*set empathy +10
+*set living_magic +5
+*set stress +5
+
+*page_break
+
+[b]== YEAR THREE: ATONEMENT IN ACTION ==[/b]
+
+*line_break
+
+You volunteer for hazardous rituals, taking risks others refuse. The faculty begin to trust you with classified errands; Zara quietly sends you to evacuate a collapsing pocket realm.
+
+*line_break
+
+*set close_calls +1
+*set power +5
+*set fame +5
+
+*page_break
+
+[b]== YEAR FOUR: TURNING SHAME INTO SHIELD ==[/b]
+
+*line_break
+
+You design a ward that converts excess guilt into stabilizing mana. It's experimental, but it keeps a dozen apprentices safe during a training mishap.
+
+*line_break
+
+*set redemption_oath true
+*set campaign_route "redemption_arc"
+*set collaboration +5
+
+*page_break
+
+[i]"You're rewriting your own story,"[/i] Polly murmurs. [i]"Maybe Avalon's too."[/i]
+
+*line_break
+
+The crisis alarm rings. Another chance to make things right.
+
+*page_break
+
+*finish The redemption arc races to the World Tree
+
+*goto_scene year_two_crisis

--- a/choicescript_game/scenes/rivalry_path.txt
+++ b/choicescript_game/scenes/rivalry_path.txt
@@ -1,0 +1,61 @@
+*comment Rivalry-driven power seeker arc
+
+*label start
+
+[b]== THE RIVALRY ASCENT ==[/b]
+
+*line_break
+
+Zara hangs a dueling ladder in the Grand Hall with your name at the top—provisional, challenged weekly. The entire academy watches your every move.
+
+*page_break
+
+Year Two is a blur of sanctioned duels, speed-research contests, and late-night training. You learn to turn spite into fuel and to study opponents as carefully as spells.
+
+*line_break
+
+*set rivalry_heat +10
+*set power +10
+*set confidence +5
+
+*page_break
+
+[b]== YEAR THREE: THE EDGE HARDENS ==[/b]
+
+*line_break
+
+Your rivals adapt. Grey turns diplomatic techniques into feints; Aria's protégés copy your spell forms. You respond with unexpected collaborations—brief alliances that leave opponents off-balance.
+
+*line_break
+
+*set collaboration +5
+*set boundary_magic +5
+*set fame +10
+
+*page_break
+
+[b]== YEAR FOUR: TITLE ON THE LINE ==[/b]
+
+*line_break
+
+A formal tournament is announced: winner earns an invitation to Avalon’s strategic council. Every victory heightens the pressure; every failure would topple your legend.
+
+*line_break
+
+*set rivalry_heat +15
+*set campaign_route "rivalry_arc"
+*set stress +5
+
+*page_break
+
+[i]"Be careful, ${name},"[/i] Polly warns. [i]"When everyone wants to beat you, they might forget the bigger threat."[/i]
+
+*line_break
+
+The crisis alarm interrupts the next challenge. Every rival stares at you, waiting to see if competition yields to survival.
+
+*page_break
+
+*finish The rivalry pauses for the crisis
+
+*goto_scene year_two_crisis

--- a/choicescript_game/scenes/year_two_crisis.txt
+++ b/choicescript_game/scenes/year_two_crisis.txt
@@ -136,6 +136,50 @@ All three of your mentors, working in crisis mode.
 
   *goto crisis_coordination
 
+*if campaign_route = "cooperative_arc"
+  You rally your Accord members without even being asked, slotting them into Aria's perimeter, Zara's shield wall, and Izack's command post simultaneously.
+
+  *set path_contribution_bonus +12
+  *set cooperative_accord +5
+  *set collaboration_check true
+
+  Izack looks relieved. [b]"Your network is exactly what we need. Keep them synced."[/b]
+
+  *goto crisis_cooperative
+
+*if campaign_route = "rivalry_arc"
+  Rivals swarm the courtyard. They expected to outdo you—now they expect you to lead. Zara jerks her chin toward the cracking bark.
+
+  *set path_contribution_bonus +8
+  *set rivalry_heat +5
+  *set confidence +3
+
+  [b]"Beat this,"[/b] one of your challengers mutters. Fine. You will.
+
+  *goto crisis_rivalry
+
+*if campaign_route = "redemption_arc"
+  The ledger of debts flashes in your mind. If Avalon falls, you never make things right.
+
+  *set path_contribution_bonus +10
+  *set redemption_oath true
+  *set empathy +3
+
+  Aria's eyes soften. [b]"Use that guilt. Channel it into the anchor, ${name}."[/b]
+
+  *goto crisis_redemption
+
+*if campaign_route = "political_arc"
+  You scan the chaos like a council chamber—mapping influence networks, assigning tasks to those who will listen.
+
+  *set path_contribution_bonus +10
+  *set manipulation_network +5
+  *set collaboration +3
+
+  Izack meets your gaze. [b]"You take the northern teams. Make sure they're actually sharing information."[/b]
+
+  *goto crisis_political
+
 *comment ================================================
 *comment PATH-SPECIFIC CONTRIBUTIONS
 *comment ================================================
@@ -441,6 +485,86 @@ The fate of Avalon rests on this choice.
 *comment ================================================
 *comment THE CHOICE - BRANCH POINT 2
 *comment ================================================
+
+*label crisis_cooperative
+
+[b]COOPERATIVE RESPONSE[/b]
+
+*line_break
+
+Your Accord members form triads, sharing mana and tasks mid-spell. The flow of information stabilizes the panicking crowd as much as your shields.
+
+*line_break
+
+*set collaborative_magic +5
+*set communication_vs_domination +5
+
+*page_break
+
+When Zara barks for reinforcements, your network answers before she finishes the sentence. When Aria needs data, three students provide it in unison.
+
+*line_break
+
+The crisis stops feeling like chaos; it becomes choreography.
+
+*goto crisis_choice
+
+*label crisis_rivalry
+
+[b]RIVALRY RESPONSE[/b]
+
+*line_break
+
+You bark orders like challenges. "Grey, prove you can match my barrier control! Alaric, unless you want second place forever, reinforce the eastern root!"
+
+*line_break
+
+*set power +5
+*set rivalry_heat +5
+
+*page_break
+
+Your rivals grit their teeth and comply, eager to outperform you—and in doing so, they stabilize whole sections of the courtyard. The competition becomes a weapon against the collapse.
+
+*goto crisis_choice
+
+*label crisis_redemption
+
+[b]REDEMPTION RESPONSE[/b]
+
+*line_break
+
+You kneel by the cracked bark, pressing the guilt-ward you designed into the fissure. It glows, absorbing ambient despair from the crowd and turning it into stabilizing energy.
+
+*line_break
+
+*set empathy +5
+*set redemption_oath true
+
+*page_break
+
+"I'm sorry," you whisper to the World Tree—and feel it steady beneath your palm. Aria nods once, trusting you with a section of the anchor.
+
+*goto crisis_choice
+
+*label crisis_political
+
+[b]POLITICAL RESPONSE[/b]
+
+*line_break
+
+You pair students from rival factions together, forcing cooperation where none existed. You draft a quick charter—authority to make emergency calls—and get Izack to sign it mid-cast.
+
+*line_break
+
+*set manipulation_network +5
+*set collaboration +5
+
+*page_break
+
+With hierarchy clarified, panic ebbs. Teams report efficiently, and the worst rumors die before they spread.
+
+*goto crisis_choice
 
 *label crisis_choice
 

--- a/choicescript_game/startup.txt
+++ b/choicescript_game/startup.txt
@@ -27,6 +27,10 @@
   year_one_trial
   year_two_start
   path_selection
+  collaborative_mastery
+  rivalry_path
+  redemption_path
+  political_web
   research_path
   combat_path
   diplomatic_path
@@ -221,10 +225,16 @@
 
 *comment Path Tracking
 *create chosen_path "none"
+*create campaign_route "standard"
 *create expedition_choice "none"
 *create artifact_earned "none"
 *create secret_paths_found 0
 *create hidden_lore_discovered 0
+*create cooperative_accord 0
+*create rivalry_heat 0
+*create redemption_oath false
+*create manipulation_network 0
+*create campaign_finale ""
 
 *comment Failure & Consequence Tracking
 *create failures 0


### PR DESCRIPTION
## Summary
- add four alternative campaign routes (cooperative scholar, rivalry ascent, redemption arc, political web) with dedicated scene files and stat tracking
- integrate new campaign routing through path selection, crisis scenes, and final expedition/avalon crisis bespoke climaxes
- add unique finale labels in endings to deliver tailored epilogues for each new long-form arc

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239ff21fb88322a7bde64af05dff5a)