### PR TITLE
security: redact exposed provider keys

### DIFF
--- a/archive/Open Ai and Claudie.txt
+++ b/archive/Open Ai and Claudie.txt
@@ -1,5 +1,5 @@
 REDACTED
 
-This file previously contained a plaintext Anthropic API key.
+This file previously contained plaintext provider API keys.
 Do not store provider keys or credentials in this repository.
 Use local environment variables or a secrets manager instead.

--- a/archive/Open Ai and Claudie.txt
+++ b/archive/Open Ai and Claudie.txt
@@ -1,2 +1,5 @@
-OPENAI_API_KEY=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
-ANTHROPIC_API_KEY=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
+REDACTED
+
+This file previously contained a plaintext Anthropic API key.
+Do not store provider keys or credentials in this repository.
+Use local environment variables or a secrets manager instead.

--- a/docs/avalon_materials/antropic for ai stuff.txt
+++ b/docs/avalon_materials/antropic for ai stuff.txt
@@ -1,4 +1,5 @@
-antropic for ai stuff 
-https://console.anthropic.com/dashboard
-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
+REDACTED
 
+This file previously contained a plaintext Anthropic API key.
+Do not store provider keys or credentials in this repository.
+Use local environment variables or a secrets manager instead.

--- a/docs/avalon_materials/antropic for ai stuff.txt
+++ b/docs/avalon_materials/antropic for ai stuff.txt
@@ -1,5 +1,5 @@
 REDACTED
 
-This file previously contained a plaintext Anthropic API key.
+This file previously contained plaintext provider API keys.
 Do not store provider keys or credentials in this repository.
 Use local environment variables or a secrets manager instead.


### PR DESCRIPTION
## Summary
- Replaces plaintext provider-key files with redacted safety notices.
- Removes current-tree Anthropic and OpenAI key material from the reported paths.

## Validation
- `rg --hidden --glob '!/.git/**' 'sk-ant-api[0-9A-Za-z_-]{20,}' C:\Users\issda\aethromoor-novel` => no matches
- `rg --hidden --glob '!/.git/**' 'sk-proj-[A-Za-z0-9_-]{20,}' C:\Users\issda\aethromoor-novel` => no matches
- `rg --hidden --glob '!/.git/**' 'sk-[A-Za-z0-9]{32,}' C:\Users\issda\aethromoor-novel` => no matches
- `rg --hidden --glob '!/.git/**' 'gh[pousr]_[A-Za-z0-9_]{20,}' C:\Users\issda\aethromoor-novel` => no matches

## Security note
This PR makes the current repository tree safe, but it does not revoke provider credentials or purge older git history. Any exposed Anthropic/OpenAI keys should be rotated in the provider consoles. If those keys were live, history rewrite with BFG or `git filter-repo` is still needed after coordination.

Fixes #179.
Fixes #180.